### PR TITLE
Update the unit test for invalid reference

### DIFF
--- a/test/ex_aws_auto_scaling_group_test.exs
+++ b/test/ex_aws_auto_scaling_group_test.exs
@@ -1,8 +1,4 @@
 defmodule ExAwsAutoScalingGroupTest do
   use ExUnit.Case
-  doctest ExAwsAutoScalingGroup
-
-  test "greets the world" do
-    assert ExAwsAutoScalingGroup.hello() == :world
-  end
+  doctest ExAws.AutoScalingGroup
 end


### PR DESCRIPTION
The doctest string was invalid. Didn't include the dot to separate the names