### PR TITLE
Update mix.exs to loosen ex_aws requirements

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule ExAwsAutoScalingGroup.Mixfile do
       {:sweet_xml, ">= 0.0.0", only: [:dev, :test]},
       {:poison, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.16", only: [:dev, :test]},
-      {:ex_aws, "~> 2.0.0"}
+      {:ex_aws, "~> 2.0"}
     ]
   end
 end


### PR DESCRIPTION
remove 3rd decimal point specifier so that ex_aws 2.1 can be used